### PR TITLE
Use Go 1.11 Modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# IntelliJ IDEA
+.idea/
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/inabajunmr/treview
+
+require (
+	github.com/PuerkitoBio/goquery v1.4.1
+	github.com/andybalholm/cascadia v1.0.0 // indirect
+	github.com/spf13/cobra v0.0.3
+	github.com/spf13/pflag v1.0.3 // indirect
+	golang.org/x/net v0.0.0-20181003013248-f5e5bdd77824 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/PuerkitoBio/goquery v1.4.1 h1:smcIRGdYm/w7JSbcdeLHEMzxmsBQvl8lhf0dSw2nzMI=
+github.com/PuerkitoBio/goquery v1.4.1/go.mod h1:T9ezsOHcCrDCgA8aF1Cqr3sSYbO/xgdy8/R/XiIMAhA=
+github.com/andybalholm/cascadia v1.0.0 h1:hOCXnnZ5A+3eVDX8pvgl4kofXv2ELss0bKcqRySc45o=
+github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
+github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
+github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20181003013248-f5e5bdd77824 h1:MkjFNbaZJyH98M67Q3umtwZ+EdVdrNJLqSwZp5vcv60=
+golang.org/x/net v0.0.0-20181003013248-f5e5bdd77824/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
# Summary

* Use Go 1.11 Modules
* Add `.idea/` for gitignore

## Usage

Setting `GO111MODULE=on` using the env.

```bash
$ export GO111MODULE=on
```

Build the module. This will automatically add missing or unconverted dependencies as needed to satisfy imports for this particular build invocation.

```bash
$ go build ./...
```

### IntelliJ IDEA

Use Go 1.11 and enable Go Modules option

<img width="778" alt="2018-10-03 14 52 42" src="https://user-images.githubusercontent.com/34958495/46392347-0b748f00-c71c-11e8-89ca-80f15744d2e3.png">

## Link

* [Modules · golang/go Wiki](https://github.com/golang/go/wiki/Modules)